### PR TITLE
feat: add custom posttype to widget filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     "wpackagist-plugin/allow-multiple-accounts": ">=3.0",
     "wpackagist-plugin/better-wp-security": ">=7.9",
     "wpackagist-plugin/classic-editor": ">=1.6",
+    "wpackagist-plugin/classic-widgets": ">=0.3",
     "wpackagist-plugin/no-category-parents": ">=0.2.4.1",
     "wpackagist-plugin/user-role-editor": ">=4.39",
     "wpackagist-plugin/user-switching": ">=1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f953fc56e400b39c7ec80d364cd2594f",
+    "content-hash": "17345f66f04f53bcd27c7f597eb0a7c7",
     "packages": [
         {
             "name": "composer/installers",
@@ -430,6 +430,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/classic-editor/"
+        },
+        {
+            "name": "wpackagist-plugin/classic-widgets",
+            "version": "0.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/classic-widgets/",
+                "reference": "tags/0.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/classic-widgets.0.3.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/classic-widgets/"
         },
         {
             "name": "wpackagist-plugin/no-category-parents",

--- a/wordpress/wp-content/themes/sydney-child/custom-posttype-widget.php
+++ b/wordpress/wp-content/themes/sydney-child/custom-posttype-widget.php
@@ -1,0 +1,7 @@
+<?php
+function widget_posts_args_add_custom_type($params) {
+    //override the default posttype here. append Books
+    $params['post_type'] = array('post','book');
+    return $params;
+}
+add_filter('widget_posts_args', 'widget_posts_args_add_custom_type');

--- a/wordpress/wp-content/themes/sydney-child/functions.php
+++ b/wordpress/wp-content/themes/sydney-child/functions.php
@@ -16,12 +16,33 @@ function sydney_child_enqueue() {
 
 }
 
-/* ADD YOUR CUSTOM FUNCTIONS BELOW */
+/**
+ * Enqueues the Fontawesome from Parent (Sydney) theme
+ *
+ */
+add_action('wp_enqueue_scripts','fontawesome_style_enqueue');
+function fontawesome_style_enqueue(){
+    //TODO: find the admin option to include this globally vs in the code.
+    wp_enqueue_style('fontawesome', get_template_directory_uri() . '/fonts/font-awesome-v5/all.min.css');
+}
+
 
 /**
  * Include custom shortcode here.
  */
 include_once ('custom-shortcodes.php');
+
+/**
+ * Include custom PostType widget here.
+ */
+include_once ('custom-posttype-widget.php');
+
+//filter post_title to append type (if 'book')
+add_filter('the_title', 'wpchad_filter_example', 10, 2);
+function wpchad_filter_example($title ,$id) {
+    //if posttype is 'book'                        go get the publication year here.
+    return (get_post_type($id) == "book") ? '<i class="fas fa-book book-icon"></i>'. $title . ' published ('.get_field( "publication_year", $id , true)['value'].')' : $title ;
+}
 
 /**
  * CHILD - Theme dashboard.

--- a/wordpress/wp-content/themes/sydney-child/style.css
+++ b/wordpress/wp-content/themes/sydney-child/style.css
@@ -11,3 +11,4 @@ Text Domain: sydney-child
 */
 
 .test_class {background-color:yellow; color:red;}
+.book-icon {margin-right:.2em;}


### PR DESCRIPTION
- added a filter to 'recent post' widget to include a custom post_type of 'Book'.
- style the list item of 'Book' with an icon from fontawesome.
- included some metadata from ACF for a publication year for the custom post_type now being listed.

(also added classic widget plugin....the filter was problematic within blocks) - TODO: see why this is a problem. 